### PR TITLE
Check if wait waits long enough

### DIFF
--- a/tests/test.hs
+++ b/tests/test.hs
@@ -190,6 +190,17 @@ main = defaultMain $ testGroup "Tests"
       result <- timeout (10^5) $ Immortal.wait thread
 
       result @?= Just ()
+
+  , testCase "wait waits long enough" $ do
+      tv <- atomically $ newTVar True
+      thread <- Immortal.create $ \t -> do
+        delay
+        atomically $ writeTVar tv False
+        Immortal.stop t
+      _ <- Immortal.wait thread
+
+      v <- atomically $ readTVar tv
+      v @?= False
   ]
 
 keepTrue :: TVar Bool -> IO ()


### PR DESCRIPTION
Since the previous test only checked that `wait` doesn't wait for too
long, this would provide a better test coverage.